### PR TITLE
Add React demo with banner, carousel, and masonry articles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# showcase-demo
+# Showcase Demo
+
+This repo contains a minimal React demo without a build step. The home page includes:
+
+- A banner section
+- An image carousel
+- Article previews in a masonry layout
+
+Open `index.html` in a browser to view the demo.

--- a/app.js
+++ b/app.js
@@ -1,0 +1,68 @@
+const { useEffect, useState } = React;
+
+function Banner() {
+  return React.createElement('div', { className: 'banner' }, 'Welcome to the Showcase Demo');
+}
+
+function Carousel({ images, interval = 3000 }) {
+  const [index, setIndex] = useState(0);
+
+  useEffect(() => {
+    const id = setInterval(() => {
+      setIndex((i) => (i + 1) % images.length);
+    }, interval);
+    return () => clearInterval(id);
+  }, [images, interval]);
+
+  return React.createElement(
+    'div',
+    { className: 'carousel' },
+    images.map((src, i) =>
+      React.createElement('img', {
+        key: src,
+        src,
+        className: i === index ? 'active' : '',
+        alt: `slide-${i + 1}`,
+      })
+    )
+  );
+}
+
+function MasonryArticles({ articles }) {
+  return React.createElement(
+    'div',
+    { className: 'masonry' },
+    articles.map((art, i) =>
+      React.createElement(
+        'div',
+        { key: i, className: 'article' },
+        React.createElement('h3', null, art.title),
+        React.createElement('p', null, art.excerpt)
+      )
+    )
+  );
+}
+
+function App() {
+  const images = [
+    'https://via.placeholder.com/800x200?text=Slide+1',
+    'https://via.placeholder.com/800x200?text=Slide+2',
+    'https://via.placeholder.com/800x200?text=Slide+3',
+  ];
+
+  const articles = Array.from({ length: 6 }).map((_, i) => ({
+    title: `Article ${i + 1}`,
+    excerpt:
+      'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus lacinia odio vitae vestibulum vestibulum.',
+  }));
+
+  return React.createElement(
+    React.Fragment,
+    null,
+    React.createElement(Banner, null),
+    React.createElement(Carousel, { images }),
+    React.createElement(MasonryArticles, { articles })
+  );
+}
+
+ReactDOM.createRoot(document.getElementById('root')).render(React.createElement(App));

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Showcase Demo</title>
+  <link rel="stylesheet" href="style.css" />
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+</head>
+<body>
+  <div id="root"></div>
+  <script src="app.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -1,0 +1,60 @@
+body {
+  margin: 0;
+  font-family: Arial, sans-serif;
+}
+
+.banner {
+  background: #4a90e2;
+  color: white;
+  padding: 60px 20px;
+  text-align: center;
+  font-size: 2em;
+}
+
+.carousel {
+  position: relative;
+  overflow: hidden;
+  height: 200px;
+  margin: 20px;
+}
+
+.carousel img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+  position: absolute;
+  top: 0;
+  left: 0;
+  opacity: 0;
+  transition: opacity 0.5s ease-in-out;
+}
+
+.carousel img.active {
+  opacity: 1;
+}
+
+.masonry {
+  column-count: 3;
+  column-gap: 1em;
+  padding: 20px;
+}
+
+.article {
+  break-inside: avoid;
+  background: #f4f4f4;
+  margin-bottom: 1em;
+  padding: 10px;
+  border-radius: 4px;
+}
+
+@media (max-width: 800px) {
+  .masonry {
+    column-count: 2;
+  }
+}
+
+@media (max-width: 500px) {
+  .masonry {
+    column-count: 1;
+  }
+}


### PR DESCRIPTION
## Summary
- add a simple React demo site served via static HTML
- include basic styles for banner, carousel, and masonry articles
- document the demo in the README

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687871c2a9208320bef6b9dcc3065d6d